### PR TITLE
Add a range system and indicator

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -248,6 +248,7 @@ MonoBehaviour:
   hovered: {fileID: 21300000, guid: ceb49467a99757244840b5311324136e, type: 3}
   infected: {fileID: 21300000, guid: b59b3ac23d1fd0b42ab6d5bff1106ebf, type: 3}
   infectedHovered: {fileID: 21300000, guid: 4633b5ebe23c1ad40bbf80d4461a1919, type: 3}
+  range: {fileID: 21300000, guid: ef5dbcddee311e74bad60502711b5c4e, type: 3}
 --- !u!114 &221309543
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -260,6 +261,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f36ed3fb2fc69748aa5000315eb0894, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  globalManager: {fileID: 967982320}
+  startInfected: 0
 --- !u!114 &221309544
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -330,7 +333,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   startingPoint: {x: -6.5, y: 0.5, z: -6.5}
-  length: 4
+  length: 5
   cubeMaterial: {fileID: 2100000, guid: 62f3ca34b25de0142b093da155f228ba, type: 2}
   cornerMaterial: {fileID: 2100000, guid: 792532f36d033f84cbe62512838d48c0, type: 2}
   physicMaterial: {fileID: 13400000, guid: 7794b99f92cb24141a68b171d3d93cda, type: 2}
@@ -655,6 +658,50 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   zoomSpeed: 1
+--- !u!1 &967982319
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 967982321}
+  - component: {fileID: 967982320}
+  m_Layer: 0
+  m_Name: Global Host Manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &967982320
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 967982319}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 34f4766a4b04a7144a054a3ff37dcb52, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &967982321
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 967982319}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -3.706988, y: -12.917191, z: -5.2614555}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1454872522
 GameObject:
   m_ObjectHideFlags: 0
@@ -733,6 +780,7 @@ MonoBehaviour:
   hovered: {fileID: 21300000, guid: ceb49467a99757244840b5311324136e, type: 3}
   infected: {fileID: 21300000, guid: b59b3ac23d1fd0b42ab6d5bff1106ebf, type: 3}
   infectedHovered: {fileID: 21300000, guid: 4633b5ebe23c1ad40bbf80d4461a1919, type: 3}
+  range: {fileID: 21300000, guid: ef5dbcddee311e74bad60502711b5c4e, type: 3}
 --- !u!114 &1454872526
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -745,6 +793,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f36ed3fb2fc69748aa5000315eb0894, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  globalManager: {fileID: 967982320}
+  startInfected: 0
 --- !u!212 &1454872527
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -871,6 +921,7 @@ MonoBehaviour:
   hovered: {fileID: 21300000, guid: ceb49467a99757244840b5311324136e, type: 3}
   infected: {fileID: 21300000, guid: b59b3ac23d1fd0b42ab6d5bff1106ebf, type: 3}
   infectedHovered: {fileID: 21300000, guid: 4633b5ebe23c1ad40bbf80d4461a1919, type: 3}
+  range: {fileID: 21300000, guid: ef5dbcddee311e74bad60502711b5c4e, type: 3}
 --- !u!114 &1807471372
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -883,6 +934,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f36ed3fb2fc69748aa5000315eb0894, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  globalManager: {fileID: 967982320}
+  startInfected: 0
 --- !u!212 &1807471373
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -1089,6 +1142,7 @@ MonoBehaviour:
   hovered: {fileID: 21300000, guid: ceb49467a99757244840b5311324136e, type: 3}
   infected: {fileID: 21300000, guid: b59b3ac23d1fd0b42ab6d5bff1106ebf, type: 3}
   infectedHovered: {fileID: 21300000, guid: 4633b5ebe23c1ad40bbf80d4461a1919, type: 3}
+  range: {fileID: 21300000, guid: ef5dbcddee311e74bad60502711b5c4e, type: 3}
 --- !u!114 &1992777985
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1101,6 +1155,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2f36ed3fb2fc69748aa5000315eb0894, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  globalManager: {fileID: 967982320}
+  startInfected: 1
 --- !u!212 &1992777986
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -1197,6 +1253,7 @@ SceneRoots:
   - {fileID: 705507995}
   - {fileID: 685754010}
   - {fileID: 485455107}
+  - {fileID: 967982321}
   - {fileID: 221309541}
   - {fileID: 1454872529}
   - {fileID: 1992777988}

--- a/Assets/Scripts/Host/GlobalHostManager.cs
+++ b/Assets/Scripts/Host/GlobalHostManager.cs
@@ -1,0 +1,43 @@
+using Assets.Scripts.Host;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GlobalHostManager : MonoBehaviour
+{
+    private List<Host> hosts = new();
+
+    internal void AddHost(Host host)
+    {
+        hosts.Add(host);
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    internal bool CheckInfectionRange(Host infecting, float range, out Host other)
+    {
+        float minDistance = 2f;
+        Host minHost = null;
+        foreach (Host host in hosts)
+        {
+            if (Vector3.Distance(infecting.Manager.gameObject.transform.position, host.Manager.transform.position) < minDistance * range)
+            {
+                minDistance = Vector3.Distance(infecting.Manager.gameObject.transform.position, host.Manager.transform.position);
+                minHost = host;
+            }
+        }
+
+        other = minHost;
+        return minHost is not null;
+    }
+}

--- a/Assets/Scripts/Host/GlobalHostManager.cs
+++ b/Assets/Scripts/Host/GlobalHostManager.cs
@@ -18,7 +18,7 @@ public class GlobalHostManager : MonoBehaviour
         Host minHost = null;
         foreach (Host host in hosts)
         {
-            if (Vector3.Distance(infecting.Manager.gameObject.transform.position, host.Manager.transform.position) < minDistance * range)
+            if (Vector3.Distance(infecting.Manager.gameObject.transform.position, host.Manager.transform.position) < minDistance * range && host.Infected)
             {
                 minDistance = Vector3.Distance(infecting.Manager.gameObject.transform.position, host.Manager.transform.position);
                 minHost = host;

--- a/Assets/Scripts/Host/GlobalHostManager.cs
+++ b/Assets/Scripts/Host/GlobalHostManager.cs
@@ -12,18 +12,6 @@ public class GlobalHostManager : MonoBehaviour
         hosts.Add(host);
     }
 
-    // Start is called before the first frame update
-    void Start()
-    {
-        
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        
-    }
-
     internal bool CheckInfectionRange(Host infecting, float range, out Host other)
     {
         float minDistance = 2f;

--- a/Assets/Scripts/Host/GlobalHostManager.cs
+++ b/Assets/Scripts/Host/GlobalHostManager.cs
@@ -7,18 +7,51 @@ public class GlobalHostManager : MonoBehaviour
 {
     private List<Host> hosts = new();
 
+    private bool globalRangeRender = false;
+    internal bool GlobalRangeRender
+    {
+        get => globalRangeRender;
+        set
+        {
+            if (value == true)
+            {
+                globalRangeRender = true;
+                foreach (Host host in hosts)
+                {
+                    host.RangeRendered = true;
+                }
+            }
+            else
+            {
+                globalRangeRender = false;
+                foreach (Host host in hosts)
+                {
+                    host.RangeRendered = false;
+                }
+            }
+        }
+    }
+
     internal void AddHost(Host host)
     {
         hosts.Add(host);
     }
 
+    void Update()
+    {
+        if (Input.GetKeyDown(KeyCode.Space))
+        {
+            GlobalRangeRender = !GlobalRangeRender;
+        }
+    }
+
     internal bool CheckInfectionRange(Host infecting, float range, out Host other)
     {
-        float minDistance = 2f;
+        float minDistance = range;
         Host minHost = null;
         foreach (Host host in hosts)
         {
-            if (Vector3.Distance(infecting.Manager.gameObject.transform.position, host.Manager.transform.position) < minDistance * range && host.Infected)
+            if (Vector3.Distance(infecting.Manager.gameObject.transform.position, host.Manager.transform.position) < minDistance && host.Infected)
             {
                 minDistance = Vector3.Distance(infecting.Manager.gameObject.transform.position, host.Manager.transform.position);
                 minHost = host;

--- a/Assets/Scripts/Host/GlobalHostManager.cs.meta
+++ b/Assets/Scripts/Host/GlobalHostManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34f4766a4b04a7144a054a3ff37dcb52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Host/Host Behavior/HostMovement.cs
+++ b/Assets/Scripts/Host/Host Behavior/HostMovement.cs
@@ -17,16 +17,12 @@ public class HostMovement : MonoBehaviour
     internal void Inizialize(Host host)
     {
         this.host = host;
-
     }
 
     // Start is called before the first frame update
     void Start()
     {
-        //degrees = UnityEngine.Random.value;
-        //GetComponent<Rigidbody>().AddForce(new Vector3((float)Math.Sin(degrees) * speedModifier, 0, (float)Math.Cos(degrees) * speedModifier), ForceMode.Impulse);
-
-        GetComponent<Rigidbody>().velocity = new Vector3(1, 0, 1) * speedModifier;
+        GetComponent<Rigidbody>().velocity = new Vector3(UnityEngine.Random.Range(-1f, 1f) + 0.001f, 0, UnityEngine.Random.Range(-1f, 1f) + 0.001f) * speedModifier;
     }
 
     // Update is called once per frame

--- a/Assets/Scripts/Host/Host Behavior/InfectHost.cs
+++ b/Assets/Scripts/Host/Host Behavior/InfectHost.cs
@@ -26,13 +26,19 @@ public class InfectHost : MonoBehaviour
     internal void Initilize(Host host)
     {
         this.host = host;
-    }
 
-    // Start is called before the first frame update
-    void Start()
-    {
-        normalSprite = normal;
-        hoveredSprite = hovered;
+        if (host.Infected)
+        {
+            normalSprite = infected;
+            hoveredSprite = infectedHovered;
+        }
+        else
+        {
+            normalSprite = normal;
+            hoveredSprite = hovered;
+        }
+
+        GetComponent<SpriteRenderer>().sprite = normalSprite;
     }
 
     // Update is called once per frame
@@ -48,7 +54,7 @@ public class InfectHost : MonoBehaviour
             held = false;
         }
 
-        if (Input.GetKey(KeyCode.Return) && !host.Infected && selected)
+        if (Input.GetKey(KeyCode.Return) && !host.Infected && selected && host.Manager.globalManager.CheckInfectionRange(host, 1, out Host other))
         {
             host.Infected = true;
             normalSprite = infected;

--- a/Assets/Scripts/Host/Host Behavior/InfectHost.cs
+++ b/Assets/Scripts/Host/Host Behavior/InfectHost.cs
@@ -19,9 +19,11 @@ public class InfectHost : MonoBehaviour
     public Sprite hovered;
     public Sprite infected;
     public Sprite infectedHovered;
+    public Sprite range;
 
     private Sprite normalSprite;
     private Sprite hoveredSprite;
+    private GameObject rangeRenderer;
 
     internal void Initilize(Host host)
     {
@@ -41,13 +43,27 @@ public class InfectHost : MonoBehaviour
         GetComponent<SpriteRenderer>().sprite = normalSprite;
     }
 
+    private void Start()
+    {
+        rangeRenderer = new GameObject("Host Range Renderer");
+        rangeRenderer.AddComponent<SpriteRenderer>();
+        rangeRenderer.GetComponent<SpriteRenderer>().sprite = range;
+        rangeRenderer.GetComponent<SpriteRenderer>().color = new Color(255, 0, 0, 50);
+        rangeRenderer.GetComponent<SpriteRenderer>().transform.rotation = Quaternion.Euler(90, 0, 0);
+        rangeRenderer.SetActive(false);
+    }
+
     // Update is called once per frame
     void Update()
     {
+        rangeRenderer.transform.position = transform.position + new Vector3(0, -0.1f, 0);
+
         if (Input.GetMouseButtonDown(0) && selected && !held)
         {
             selected = false;
             GetComponent<SpriteRenderer>().sprite = normalSprite;
+            if (!host.Manager.globalManager.GlobalRangeRender)
+                host.RangeRendered = false;
         }
         else if (!Input.GetMouseButtonDown(0) && held)
         {
@@ -61,6 +77,17 @@ public class InfectHost : MonoBehaviour
             hoveredSprite = infectedHovered;
             selected = false;
             GetComponent<SpriteRenderer>().sprite = normalSprite;
+            if (!host.Manager.globalManager.GlobalRangeRender)
+                host.RangeRendered = false;
+        }
+
+        if ((host.Manager.globalManager.GlobalRangeRender || host.RangeRendered) && host.Infected)
+        {
+            rangeRenderer.SetActive(true);
+        }
+        else
+        {
+            rangeRenderer.SetActive(false);
         }
     }
 
@@ -73,7 +100,7 @@ public class InfectHost : MonoBehaviour
         {
             selected = true;
             held = true;
-
+            host.RangeRendered = true;
             
             GetComponent<SpriteRenderer>().sprite = hoveredSprite;
         }

--- a/Assets/Scripts/Host/Host Behavior/InfectHost.cs
+++ b/Assets/Scripts/Host/Host Behavior/InfectHost.cs
@@ -48,7 +48,7 @@ public class InfectHost : MonoBehaviour
         rangeRenderer = new GameObject("Host Range Renderer");
         rangeRenderer.AddComponent<SpriteRenderer>();
         rangeRenderer.GetComponent<SpriteRenderer>().sprite = range;
-        rangeRenderer.GetComponent<SpriteRenderer>().color = new Color(255, 0, 0, 50);
+        rangeRenderer.GetComponent<SpriteRenderer>().color = new Color(191f / 255f, 0, 0, 100f / 255f);
         rangeRenderer.GetComponent<SpriteRenderer>().transform.rotation = Quaternion.Euler(90, 0, 0);
         rangeRenderer.SetActive(false);
     }

--- a/Assets/Scripts/Host/Host Behavior/InfectHost.cs
+++ b/Assets/Scripts/Host/Host Behavior/InfectHost.cs
@@ -3,6 +3,7 @@ using Palmmedia.ReportGenerator.Core.Parser.Analysis;
 using System.Collections;
 using System.Collections.Generic;
 using Unity.VisualScripting;
+using UnityEditor.SearchService;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;

--- a/Assets/Scripts/Host/Host.cs
+++ b/Assets/Scripts/Host/Host.cs
@@ -11,14 +11,16 @@ namespace Assets.Scripts.Host
         public bool Infected { get; set; }
         public int Level { get; set; }
         public int Speed { get; set; }
+        internal HostManager Manager { get; set; }
 
-        public Host(int level)
+        public Host(int level, HostManager manager)
         {
             Random random = new();
 
             Infected = false;
             Level = level;
             Speed = random.Next(1, 5);
+            Manager = manager;
         }
     }
 }

--- a/Assets/Scripts/Host/Host.cs
+++ b/Assets/Scripts/Host/Host.cs
@@ -11,9 +11,10 @@ namespace Assets.Scripts.Host
         public bool Infected { get; set; }
         public int Level { get; set; }
         public int Speed { get; set; }
-        internal HostManager Manager { get; set; }
+        internal HostManager Manager { get; }
+        internal bool RangeRendered { get; set; }
 
-        public Host(int level, HostManager manager)
+        internal Host(int level, HostManager manager)
         {
             Random random = new();
 
@@ -21,6 +22,7 @@ namespace Assets.Scripts.Host
             Level = level;
             Speed = random.Next(1, 5);
             Manager = manager;
+            RangeRendered = false;
         }
     }
 }

--- a/Assets/Scripts/Host/HostManager.cs
+++ b/Assets/Scripts/Host/HostManager.cs
@@ -16,5 +16,6 @@ public class HostManager : MonoBehaviour
 
         gameObject.GetComponent<InfectHost>().Initilize(host);
         gameObject.GetComponent<HostMovement>().Inizialize(host);
+        globalManager.AddHost(host);
     }
 }

--- a/Assets/Scripts/Host/HostManager.cs
+++ b/Assets/Scripts/Host/HostManager.cs
@@ -7,10 +7,12 @@ public class HostManager : MonoBehaviour
 {
     private Host host;
 
+    public GlobalHostManager globalManager;
+
     // Start is called before the first frame update
     void Start()
     {
-        host = new(1);
+        host = new(1, this);
 
         gameObject.GetComponent<InfectHost>().Initilize(host);
         gameObject.GetComponent<HostMovement>().Inizialize(host);

--- a/Assets/Scripts/Host/HostManager.cs
+++ b/Assets/Scripts/Host/HostManager.cs
@@ -1,4 +1,5 @@
 using Assets.Scripts.Host;
+using Palmmedia.ReportGenerator.Core.Parser.Analysis;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -8,14 +9,21 @@ public class HostManager : MonoBehaviour
     private Host host;
 
     public GlobalHostManager globalManager;
+    public bool startInfected;
 
     // Start is called before the first frame update
     void Start()
     {
         host = new(1, this);
 
+        if (startInfected)
+        {
+            host.Infected = true;
+        }
+
         gameObject.GetComponent<InfectHost>().Initilize(host);
         gameObject.GetComponent<HostMovement>().Inizialize(host);
         globalManager.AddHost(host);
+        
     }
 }

--- a/Assets/Sprites/infection_range_indicator.png
+++ b/Assets/Sprites/infection_range_indicator.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80a1d054a21f5142ddddb16314de804b29e43a7d0bbb02098114c04d510b6720
+size 1485

--- a/Assets/Sprites/infection_range_indicator.png.meta
+++ b/Assets/Sprites/infection_range_indicator.png.meta
@@ -1,0 +1,127 @@
+fileFormatVersion: 2
+guid: ef5dbcddee311e74bad60502711b5c4e
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 13
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Description:**
Adds a feature where the hosts have to be within range of another infected host in order to be infected. Also adds a visual range and a toggle for said visual range.

**Full Changelog:**
- Added a system where hosts must within range of another infected host to be infected
- Created the method for the above in such a way that the range multiplier can be modified and that the closest host can be retrieved
- Added a new sprite to indicate the infection range
- Made this sprite display when the "RangeRendered" boolean in the Host class is true
- Added a hotkey to enable the range display on all infected hosts
- Made the range display on the currently selected infected host

**TODO:**
- Make the range display properly scale with the actual range (currently only shows default range aka x1 mult)